### PR TITLE
Stop crashing when some ImageMagick module can't be loaded

### DIFF
--- a/src/formats.cpp
+++ b/src/formats.cpp
@@ -37,11 +37,15 @@ void Formats::loadFormats()
 {
 //#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     list<CoderInfo> coderList;
-    coderInfoList(&coderList,
-                  CoderInfo::TrueMatch,
-                  CoderInfo::AnyMatch,
-                  CoderInfo::AnyMatch);
-
+    try {
+        coderInfoList(&coderList,
+                      CoderInfo::TrueMatch,
+                      CoderInfo::AnyMatch,
+                      CoderInfo::AnyMatch);
+    }
+    catch (ErrorModule &e) {
+        cerr << e.what() << endl;
+    }
     list<CoderInfo>::iterator entry = coderList.begin();
     QString readableExts;
 


### PR DESCRIPTION
When some ImageMagick module can't be loaded (because of eg. missing shared libraries), print the error and continue instead of crashing.

Fixes #50