### PR TITLE
simplify AppImage deployment

### DIFF
--- a/package/AppImage/converseen-appimage.sh
+++ b/package/AppImage/converseen-appimage.sh
@@ -17,17 +17,11 @@ export OUTNAME=Converseen-"$VERSION"-anylinux-"$ARCH".AppImage
 wget --retry-connrefused --tries=30 "$SHARUN" -O ./quick-sharun
 chmod +x ./quick-sharun
 ./quick-sharun \
-	/usr/bin/converseen                \
-	/usr/lib/libheif/libheif-dav1d.so  \
-	/usr/lib/libheif/libheif-rav1e.so  \
-	/usr/lib/libheif/libheif-svtenc.so \
-	/usr/lib/libSvtAv1Enc.so           \
+	/usr/bin/converseen       \
+	/usr/lib/libSvtAv1Enc.so  \
 	/usr/lib/libavcodec.so
 
 cat >> ./AppDir/.env << 'EOF'
-# Set heif plugins dir
-LIBHEIF_PLUGIN_PATH=${SHARUN_DIR}/lib/libheif
-
 # Set Ghostscript env
 GS_LIB="${SHARUN_DIR}/share/ghostscript/Resource/Init"
 GS_FONTPATH="${SHARUN_DIR}/share/ghostscript/Resource/Font"

--- a/package/AppImage/get-dependencies.sh
+++ b/package/AppImage/get-dependencies.sh
@@ -48,4 +48,4 @@ echo "Installing debloated packages..."
 echo "---------------------------------------------------------------"
 wget --retry-connrefused --tries=30 "$EXTRA_PACKAGES" -O ./get-debloated-pkgs.sh
 chmod +x ./get-debloated-pkgs.sh
-./get-debloated-pkgs.sh --add-opengl --prefer-nano qt6-base-mini gtk3-mini libxml2-mini opus-mini
+./get-debloated-pkgs.sh --add-common --prefer-nano


### PR DESCRIPTION
* `get-debloated-pkgs.sh` offers an option called `--add-common` which includes all the packages that were being listed manually + `gdk-pixbuf2-mini` which is new and was made due to this issue: https://github.com/VHSgunzo/sharun/issues/68 Even though `quick-sharun` handles glycin already, it is massive (20 MiB of dependencies) so better to just use gdk without glycin.

* libheif is now handled automatically https://github.com/pkgforge-dev/Anylinux-AppImages/pull/73 however I noticed the plugins were being selected manually instead of just passing `/usr/lib/libheif/*` is this intended? 

Note that in the current appimage releases all libheif plugins ended up being bundled, so even though it is possible to restore the old behaviour by setting `DEPLOY_LIBHEIF=0` all the plugins will still end being added. 