### PR TITLE
add `x265-mini` and remove `qt6-wayland`

### DIFF
--- a/package/AppImage/get-dependencies.sh
+++ b/package/AppImage/get-dependencies.sh
@@ -30,7 +30,6 @@ pacman -Syu --noconfirm \
 	libxrandr        \
 	libxtst          \
 	qt6ct            \
-	qt6-wayland      \
 	wget             \
 	xorg-server-xvfb \
 	rav1e            \

--- a/package/AppImage/get-dependencies.sh
+++ b/package/AppImage/get-dependencies.sh
@@ -48,4 +48,4 @@ echo "Installing debloated packages..."
 echo "---------------------------------------------------------------"
 wget --retry-connrefused --tries=30 "$EXTRA_PACKAGES" -O ./get-debloated-pkgs.sh
 chmod +x ./get-debloated-pkgs.sh
-./get-debloated-pkgs.sh --add-common --prefer-nano
+./get-debloated-pkgs.sh --add-common --prefer-nano x265-mini


### PR DESCRIPTION
👀

btw I also have `ffmpeg-mini` but this one removes `libjxl`, `librsvg` and `libopenjpeg` support from it. So if the app relies on ffmpeg for those image formats then it is not possible to add. 